### PR TITLE
fix: Autocomplete fatal error on non-action libraries

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -48,7 +48,7 @@ var Command = &cobra.Command{
 
 		logger.Info("collecting actions")
 
-		actions, err := ws.CollectActions()
+		actions, err := ws.CollectActions(true)
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/cmd/checkversions/checkversions.go
+++ b/cmd/checkversions/checkversions.go
@@ -50,7 +50,7 @@ var Command = &cobra.Command{
 		})
 		logger.Info("collecting actions")
 
-		actions, err := ws.CollectActions()
+		actions, err := ws.CollectActions(true)
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -66,7 +66,7 @@ var Command = &cobra.Command{
 
 		logger.Info("collecting actions")
 
-		actions, err := ws.CollectActions()
+		actions, err := ws.CollectActions(true)
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,0 +1,62 @@
+package list
+
+import (
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+
+	"github.com/gravitational/gamma/internal/logger"
+	"github.com/gravitational/gamma/internal/utils"
+	"github.com/gravitational/gamma/internal/workspace"
+)
+
+var workingDirectory string
+var workspaceManifest string
+
+var Command = &cobra.Command{
+	Use:   "list",
+	Short: "List all the actions in the monorepo",
+	Long:  `List all the actions in the monorepo.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		started := time.Now()
+
+		workingDirectory = utils.FetchWorkingDirectory(workingDirectory)
+
+		nd, err := utils.NormalizeDirectories(workingDirectory)
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		ws := workspace.New(workspace.Properties{
+			WorkingDirectory:  nd[0],
+			WorkspaceManifest: workspaceManifest,
+		})
+
+		logger.Info("collecting actions")
+
+		actions, err := ws.CollectActions(true)
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		if len(actions) == 0 {
+			logger.Fatal("could not find any actions")
+		}
+
+		logger.Info("found actions:")
+		for _, action := range actions {
+			logger.Infof(" ✅ %s (%s/%s)", action.Name(), action.Owner(), action.RepoName())
+		}
+
+		took := time.Since(started)
+
+		bold := text.Colors{text.FgWhite, text.Bold}
+		logger.Success(bold.Sprintf("done in %.2fs", took.Seconds()))
+	},
+}
+
+func init() {
+	Command.Flags().StringVarP(&workingDirectory, "directory", "d", "the current working directory", "directory containing the monorepo of actions")
+	Command.Flags().StringVarP(&workspaceManifest, "workspace", "w", "gamma-workspace.yml", "workspace manifest for non-javascript actions")
+}

--- a/cmd/merge/merge.go
+++ b/cmd/merge/merge.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -51,6 +52,10 @@ func init() {
 	Command.Flags().StringVarP(&workingDirectory, "directory", "d", "the current working directory", "directory containing the monorepo of actions")
 	Command.Flags().StringVarP(&workspaceManifest, "workspace", "w", "gamma-workspace.yml", "workspace manifest for non-javascript actions")
 
+	if _, err := os.Stat(workspaceManifest); os.IsNotExist(err) {
+		return
+	}
+
 	workingDirectory = utils.FetchWorkingDirectory(workingDirectory)
 	wdArr, err := utils.NormalizeDirectories(workingDirectory)
 	if err != nil {
@@ -61,7 +66,7 @@ func init() {
 		WorkspaceManifest: workspaceManifest,
 	})
 
-	actions, err := ws.CollectActions()
+	actions, err := ws.CollectActions(false)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gravitational/gamma/cmd/build"
 	"github.com/gravitational/gamma/cmd/checkversions"
 	"github.com/gravitational/gamma/cmd/deploy"
+	"github.com/gravitational/gamma/cmd/list"
 	"github.com/gravitational/gamma/cmd/merge"
 	"github.com/gravitational/gamma/internal/color"
 )
@@ -34,6 +35,7 @@ func init() {
 	cobra.AddTemplateFunc("logo", logo)
 
 	rootCmd.AddCommand(build.Command)
+	rootCmd.AddCommand(list.Command)
 	rootCmd.AddCommand(checkversions.Command)
 	rootCmd.AddCommand(merge.Command)
 	rootCmd.AddCommand(deploy.Command)
@@ -80,6 +82,8 @@ func colorize(s, name string) string {
 	switch s {
 	case build.Command.Name():
 		return color.Magenta(name)
+	case list.Command.Name():
+		return color.Purple(name)
 	case checkversions.Command.Name():
 		return color.Purple(name)
 	case deploy.Command.Name():
@@ -99,6 +103,8 @@ func emoji(s string) string {
 	switch s {
 	case build.Command.Name():
 		return "🔧"
+	case list.Command.Name():
+		return "🔍"
 	case checkversions.Command.Name():
 		return "🔍"
 	case deploy.Command.Name():

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,13 +6,14 @@ import (
 	"path"
 
 	"github.com/gravitational/gamma/internal/action"
+	"github.com/gravitational/gamma/internal/logger"
 	"github.com/gravitational/gamma/internal/node"
 	"github.com/gravitational/gamma/pkg/schema"
 	"gopkg.in/yaml.v3"
 )
 
 type Workspace interface {
-	CollectActions() ([]action.Action, error)
+	CollectActions(verbose bool) ([]action.Action, error)
 }
 
 type workspace struct {
@@ -44,7 +45,7 @@ func New(props Properties) Workspace {
 	}
 }
 
-func (w *workspace) CollectActions() ([]action.Action, error) {
+func (w *workspace) CollectActions(verbose bool) ([]action.Action, error) {
 	// TODO: don't error if rootPackage doesn't exist
 	rootPackage, err := w.readRootPackage()
 	if err != nil {
@@ -69,7 +70,11 @@ func (w *workspace) CollectActions() ([]action.Action, error) {
 
 		action, err := action.New(config)
 		if err != nil {
-			return nil, err
+			if verbose {
+				logger.Warningf("Skipping action %s: %v\n", ws.Name, err)
+			}
+			// return nil, err
+			continue
 		}
 
 		actions = append(actions, action)


### PR DESCRIPTION
In situations where pnpm workspaces include non-action, gamma would fail.

- Ignore workspaces that are missing action configuration
- Add log messages when workspaces are ignored
