### PR TITLE
feat: support node22 and node24 runtimes

### DIFF
--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -167,7 +167,7 @@ func (r *Runs) UnmarshalYAML(value *yaml.Node) error {
 
 		return nil
 
-	case "node12", "node16", "node20":
+	case "node12", "node16", "node20", "node22", "node24":
 		var javascriptRun JavascriptRun
 
 		if err := value.Decode(&javascriptRun); err != nil {
@@ -179,5 +179,5 @@ func (r *Runs) UnmarshalYAML(value *yaml.Node) error {
 		return nil
 	}
 
-	return fmt.Errorf("unsupported runs.using value: %v, expected composite, docker, node12 or node16", obj.Using)
+	return fmt.Errorf("unsupported runs.using value: %v, expected composite, docker, node12, node16, node20, node22 or node24", obj.Using)
 }


### PR DESCRIPTION
## Summary

- Add `node22` and `node24` to the allowed `runs.using` values in the schema parser
- Refresh the error message to list all supported values

## Context

GitHub Actions [deprecates the Node 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

- **2026-06-02** — Node 24 becomes the default. Node-20-manifested actions can still run via `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`.
- **2026-09-16** — Node 20 removed from runners.

Without this patch, `gamma merge` fails on any action whose `common/js-action.yml` declares `using: node24`:

```
✖ error merging action <name>: error parsing common/js-action.yml:
  unsupported runs.using value: node24,
  expected composite, docker, node12 or node16
```

Hit while bumping `HandshakesByDC/gh-actions` to node24 ahead of the GH deadline (PETI-1827).

## Test plan

- [x] `go build .` succeeds
- [x] Local binary correctly merges actions with `using: node24` (verified on HandshakesByDC/gh-actions: setup-yq, deployment-checklist, atlantis-api-plan)
- [x] Existing `node12`/`node16`/`node20` cases still resolve
- [ ] release-please cuts v1.5.0 on merge
- [ ] Downstream gh-actions monorepo synth + build green on new gamma version

🤖 Generated with [Claude Code](https://claude.com/claude-code)